### PR TITLE
Task/implement layouts

### DIFF
--- a/components/footer.component.tsx
+++ b/components/footer.component.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { Typography } from "@material-ui/core";
+import { makeStyles, createStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    link: {
+      color: "grey",
+    },
+  })
+);
+
+interface Props {}
+
+export const FooterComponent = (props: Props) => {
+  const classes = useStyles(props);
+
+  return (
+    <Typography variant="subtitle1" component="p">
+      	&copy; 2020. Developed with React
+    </Typography>
+  );
+};

--- a/components/header.component.tsx
+++ b/components/header.component.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { Typography } from "@material-ui/core";
+import { makeStyles, createStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    title: {
+      fontSize: `1.2rem`,
+    },
+  })
+);
+
+interface Props {}
+
+export const HeaderComponent = (props: Props) => {
+  const classes = useStyles(props);
+
+  return (
+    <Typography
+      variant="h1"
+      component="h1"
+      className={classes.title}
+      gutterBottom
+    >
+      Nombre página de estadísticas
+    </Typography>
+  );
+};

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,2 @@
+export * from "./header.component";
+export * from "./footer.component";

--- a/layouts/body.layout.tsx
+++ b/layouts/body.layout.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { CssBaseline, Container } from "@material-ui/core";
+import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 0,
+      padding: 0,
+      width: `100vw`,
+      maxWidth: `100%`,
+      height: `100vh`,
+      backgroundColor: "white",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      alignItems: "stretch"
+    }
+  })
+);
+
+interface Props {
+  children: any;
+}
+
+export const BodyLayout = (props: Props) => {
+  const classes = useStyles(props);
+
+  return (
+    <React.Fragment>
+      <CssBaseline />
+      <Container className={classes.root}>
+        {props.children}
+      </Container>
+    </React.Fragment>
+  );
+};

--- a/layouts/footer.layout.tsx
+++ b/layouts/footer.layout.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { makeStyles, createStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    footer: {
+      backgroundColor: "black",
+      color: "white",
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "center",
+      alignItems: "center"
+    },
+    link: {
+      color: "grey",
+    }
+  })
+);
+
+interface Props {
+  children: any
+}
+
+export const FooterLayout = (props: Props) => {
+  const classes = useStyles(props);
+
+  return (
+    <footer className={classes.footer}>
+      {props.children}
+    </footer>
+  );
+};

--- a/layouts/header.layout.tsx
+++ b/layouts/header.layout.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { makeStyles, createStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    header: {
+      padding: `1.5rem`,
+      textAlign: "center",
+      backgroundColor: "black",
+      color: "white",
+    },
+  })
+);
+
+interface Props {
+  children: any;
+}
+
+export const HeaderLayout = (props: Props) => {
+  const classes = useStyles(props);
+
+  return (
+    <header className={classes.header}>
+      {props.children}
+    </header>
+  );
+};

--- a/layouts/index.ts
+++ b/layouts/index.ts
@@ -1,0 +1,4 @@
+export * from "./body.layout";
+export * from "./header.layout"
+export * from "./main.layout";
+export * from "./footer.layout";

--- a/layouts/main.layout.tsx
+++ b/layouts/main.layout.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    main: {
+      backgroundColor: "white",
+      color: "black",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "flex-start",
+      alignContent: "stretch",
+      flexGrow: 1
+    }
+  })
+);
+
+interface Props {
+  children: any
+}
+
+export const MainLayout = (props: Props) => {
+  const classes = useStyles(props);
+
+  return (
+    <main className={classes.main}>
+      {props.children}
+    </main>
+  );
+};

--- a/pages/espana-covid-marzo.tsx
+++ b/pages/espana-covid-marzo.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import Link from "next/link";
 import * as d3 from "d3";
+import { HeaderLayout, BodyLayout, MainLayout, FooterLayout } from "../layouts";
+import { HeaderComponent, FooterComponent } from "../components";
+import { Typography } from "@material-ui/core";
 
 export default function SpainCovidChart() {
   const refSvgDomNode = React.useRef<SVGSVGElement>(null);
@@ -18,17 +21,26 @@ export default function SpainCovidChart() {
   }, []);
 
   return (
-    <div>
-      <p>Add here the description and chart</p>
-
-      <svg
-        ref={(node) => (refSvgDomNode.current = node)}
-        width="500"
-        height="500"
-      ></svg>
-      <Link href="/index">
-        <a>Volver a página principal</a>
-      </Link>
-    </div>
+    <BodyLayout>
+      <HeaderLayout>
+        <HeaderComponent />
+        <Typography variant="h2" component="h2" gutterBottom>
+          Add here the description and chart
+        </Typography>
+      </HeaderLayout>
+      <MainLayout>
+        <svg
+          ref={(node) => (refSvgDomNode.current = node)}
+          width="500"
+          height="500"
+        ></svg>
+        <Link href="/index">
+          <a>Volver a página principal</a>
+        </Link>
+      </MainLayout>
+      <FooterLayout>
+        <FooterComponent />
+      </FooterLayout>
+    </BodyLayout>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,26 @@
 import Link from "next/link";
 import Typography from "@material-ui/core/Typography";
 import { MainChartListContainer } from "../pods/main-chart-list";
+import { BodyLayout, HeaderLayout, FooterLayout, MainLayout } from "../layouts";
+import { FooterComponent, HeaderComponent } from "../components";
 
 export default function Index() {
   return (
-    <div>
-      <Typography variant="h2" gutterBottom>
-        Página principal gráficas
-      </Typography>
+    <BodyLayout>
+      <HeaderLayout>
+        <HeaderComponent />
+        <Typography variant="h2" component="h2" gutterBottom>
+          Página principal gráficas
+        </Typography>
+      </HeaderLayout>
 
-      <MainChartListContainer />
-    </div>
+      <MainLayout>
+        <MainChartListContainer />
+      </MainLayout>
+
+      <FooterLayout>
+        <FooterComponent />
+      </FooterLayout>
+    </BodyLayout>
   );
 }


### PR DESCRIPTION
Added body, header, main, footer layouts. Also, a header and footer components to show how to use them with the layouts. Examples of how to use them are in the index and espana-covid-marzo pages.

The layouts are pretty basic until we figure out which style we want to use in the charts web (TODO: make mockups in Invision or some similar design app). The approach that I would like to follow is implementing a style for mobile browsers, and later for desktop/4K browsers.